### PR TITLE
Add loongarch support

### DIFF
--- a/pyroute2/netlink/rtnl/ifinfmsg/compat.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/compat.py
@@ -33,7 +33,7 @@ if config.machine in ('i386', 'i686', 'x86_64', 's390x'):
     TUNSETPERSIST = 0x400454cb
     TUNSETOWNER = 0x400454cc
     TUNSETGROUP = 0x400454ce
-elif config.machine in ('ppc64', 'mips'):
+elif config.machine in ('ppc64', 'mips', 'loongarch64'):
     TUNSETIFF = 0x800454ca
     TUNSETPERSIST = 0x800454cb
     TUNSETOWNER = 0x800454cc

--- a/pyroute2/netlink/rtnl/ifinfmsg/proxy.py
+++ b/pyroute2/netlink/rtnl/ifinfmsg/proxy.py
@@ -32,7 +32,7 @@ if config.machine in ('i386', 'i686', 'x86_64', 'armv6l', 'armv7l', 's390x'):
     TUNSETPERSIST = 0x400454cb
     TUNSETOWNER = 0x400454cc
     TUNSETGROUP = 0x400454ce
-elif config.machine in ('ppc64', 'mips'):
+elif config.machine in ('ppc64', 'mips' , 'loongarch64'):
     TUNSETIFF = 0x800454ca
     TUNSETPERSIST = 0x800454cb
     TUNSETOWNER = 0x800454cc

--- a/pyroute2/netns/__init__.py
+++ b/pyroute2/netns/__init__.py
@@ -102,7 +102,8 @@ __NR = {'x86_': {'64bit': 308},
         'aarc': {'32bit': 375,
                  '64bit': 268},  # FIXME: EABI vs. OABI?
         'ppc6': {'64bit': 350},
-        's390': {'64bit': 339}}
+        's390': {'64bit': 339},
+        'loon': {'64bit': 268}}
 __NR_setns = __NR.get(config.machine[:4], {}).get(config.arch, 308)
 
 CLONE_NEWNET = 0x40000000


### PR DESCRIPTION
This commit is for a new architecture--loongarch.

Compilation and installation are normal in the loongarch architecture.
Tests unit test passed in pyroute2 project.
Examples,
First,loongarch architecture displays.
loongson@loongson-pc:~/dd/python-pyroute2$ lscpu | grep Architecture
Architecture:  loongarch64

Second,tests unit test passed in pyroute2 project.
loongson@loongson-pc:~/dd/python-pyroute2$ python3.7 -m nose -v tests/unit
test_common.TestAddrPool.test_alloc_aligned ... ok
test_common.TestAddrPool.test_alloc_odd ... ok
test_common.TestAddrPool.test_free ... ok
test_common.TestAddrPool.test_free_fail ... ok
test_common.TestAddrPool.test_free_reverse_fail ... ok
test_common.TestAddrPool.test_locate ... ok
test_common.TestAddrPool.test_reverse ... ok
test_common.TestAddrPool.test_setaddr_allocated ... ok
test_common.TestAddrPool.test_setaddr_free ... ok
test_common.TestCommon.test_dqn2int ... ok
test_common.TestCommon.test_hexdump ... ok
test_common.TestCommon.test_uifname ... ok
test_common.TestCommon.test_uuid32 ... ok
Ran 13 tests in 0.247s
OK

Third,users test passed in the loongarch architecture.
Users test some netns:: interfaces those also pass, such as
loongson@loongson-pc:~/dd/python-pyroute2$ sudo python3
Python 3.7.3 (default, Sep 12 2020, 09:01:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyroute2
>>> from pyroute2 import NetNS
>>> from pprint import pprint
>>> ns = NetNS('test')
>>> pprint(ns.get_links())
[{'__align': (),
  'attrs': [('IFLA_IFNAME', 'lo'),
            ('IFLA_TXQLEN', 1000),
...... 
>>> ns.close()
>>>
loongson@loongson-pc:~/dd/python-pyroute2$ sudo python3
Python 3.7.3 (default, Sep 12 2020, 09:01:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyroute2 import netns
>>> netns.create('test')
>>> print(netns.listnetns())
['test', 'aaaaaa']
>>> netns.remove('test')
>>> 

The end, we look forward to your reply and we hope this submission could be merged.
Thanks.